### PR TITLE
Use default plone styling for error messages in form.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.1 (unreleased)
 ----------------
 
+- Use default styling for error messages in forms.
+  [Julian Infanger]
+
 - Fix a bug where blocked periods were not removed when removing reserved
   slots for a sinlge day or multiple days without removing the whole
   reservation.

--- a/seantis/reservation/css/sunburst/resource.css
+++ b/seantis/reservation/css/sunburst/resource.css
@@ -258,13 +258,6 @@ a.reservation-data-update {
     text-align: center;
 }
 
-div.error {
-    background-color: #FDC;
-    border: 1px solid red;
-    padding: 4px 4px;
-    font-size: 10px;
-}
-
 .reservations-by-month .reservation-data {
      float:none;
      width: 100%;
@@ -334,19 +327,8 @@ body .enableFormTabbing fieldset {
 }
 
 body .fieldErrorBox .error {
-    margin-bottom: 5px;
-}
-
-body div.error {
-    font-size: 12px;
-
-    padding-left: 10px;
-}
-
-body div.field.error {
-    background-color: white;
-    padding-left: 0;
-    border: none;
+  margin-bottom: 5px;
+  font-size: 11px;
 }
 
 body .portalMessage {


### PR DESCRIPTION
@deiferni back to the roots :wink: 
![bildschirmfoto 2014-01-07 um 15 20 57](https://f.cloud.github.com/assets/157533/1859641/fbd9c37c-77a6-11e3-9409-b0a040c9b7a3.png)
